### PR TITLE
feature: 06-09-2025 01:28 KafkaAccountProducer created, yml fixed with kafka topics

### DIFF
--- a/src/main/java/com/itgirl/account_service_a/kafka/KafkaAccountProducer.java
+++ b/src/main/java/com/itgirl/account_service_a/kafka/KafkaAccountProducer.java
@@ -1,4 +1,41 @@
 package com.itgirl.account_service_a.kafka;
 
+import com.itgirl.account_service_a.dto.ReserveRequestDTO;
+import com.itgirl.account_service_a.dto.CommitRequestDTO;
+import com.itgirl.account_service_a.dto.ReleaseRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+
 public class KafkaAccountProducer {
+    private final String reserveTopic;
+    private final String commitTopic;
+    private final String releaseTopic;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public KafkaAccountProducer(
+            @Value("${kafka.topics.reserve}") String reserveTopic,
+            @Value("${kafka.topics.commit}") String commitTopic,
+            @Value("${kafka.topics.release}") String releaseTopic,
+            KafkaTemplate<String, Object> kafkaTemplate) {
+        this.reserveTopic = reserveTopic;
+        this.commitTopic = commitTopic;
+        this.releaseTopic = releaseTopic;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendReserve(ReserveRequestDTO reserveRequestDTO) {
+        kafkaTemplate.send(reserveTopic, reserveRequestDTO.getTransferId().toString(), reserveRequestDTO);
+    }
+
+    public void sendCommit(CommitRequestDTO commitRequestDTO) {
+        kafkaTemplate.send(commitTopic, commitRequestDTO.getTransferId().toString(), commitRequestDTO);
+    }
+
+    public void sendRelease(ReleaseRequestDTO releaseRequestDTO) {
+        kafkaTemplate.send(releaseTopic, releaseRequestDTO.getTransferId().toString(), releaseRequestDTO);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,7 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    topics:
+      reserve: account.reserve
+      commit: account.commit
+      release: account.release


### PR DESCRIPTION
Задача: 3-019-create-KafkaAccountProducer

Делала, конечно, с ИИ, он подсказал, что лучше топики не хардкодить, а прописать в yml и оттуда подтягивать, поэтому добавила в наш yml-файл topics.